### PR TITLE
Project wide tab and indent settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ let proj = try! XCProjectFile(xcodeprojURL: xcodeproj)
 try! proj.writeToXcodeproj(xcodeprojURL: xcodeproj, format: NSPropertyListFormat.OpenStepFormat)
 ```
 
+
 Carthage
 --------
 ```
 github "tomlokhorst/Xcode.swift"
 ```
+
+
 Releases
 --------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src="https://cloud.githubusercontent.com/assets/75655/10141830/f92646ca-660e-11e5-8e1e-40c90482ead0.png" width="175" alt="Xcode.swift">
 <hr>
 
+<a href="https://github.com/Carthage/Carthage"><img src="https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat" alt="Carthage compatible" /></a>
+
 Reading _and writing_ the the Xcode pbxproj file format, from Swift!
 
 The main goal of this project is to generate `project.pbxproj` files in the legacy OpenStep format used by Xcode. Using this, a project file can be modified without changing it to XML format and causing a huge git diff.
@@ -21,7 +23,11 @@ let proj = try! XCProjectFile(xcodeprojURL: xcodeproj)
 try! proj.writeToXcodeproj(xcodeprojURL: xcodeproj, format: NSPropertyListFormat.OpenStepFormat)
 ```
 
-
+Carthage
+--------
+```
+github "tomlokhorst/Xcode.swift"
+```
 Releases
 --------
 

--- a/Xcode/Xcode.xcodeproj/project.pbxproj
+++ b/Xcode/Xcode.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		E21D91A61B7B1A5D00FD0374 /* Xcode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E21D919A1B7B1A5D00FD0374 /* Xcode.framework */; };
 		E21D91AD1B7B1A5D00FD0374 /* XcodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21D91AC1B7B1A5D00FD0374 /* XcodeTests.swift */; };
 		E21D91B71B7B1A9000FD0374 /* XCProjectFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21D91B61B7B1A9000FD0374 /* XCProjectFile.swift */; };
-		E292B9C51B9236B500D75DE2 /* Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9C41B9236B500D75DE2 /* Serialization.swift */; settings = {ASSET_TAGS = (); }; };
-		E292B9C91B92380300D75DE2 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9C81B92380300D75DE2 /* Extensions.swift */; settings = {ASSET_TAGS = (); }; };
-		E292B9CB1B92384B00D75DE2 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9CA1B92384B00D75DE2 /* PBXObject.swift */; settings = {ASSET_TAGS = (); }; };
+		E292B9C51B9236B500D75DE2 /* Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9C41B9236B500D75DE2 /* Serialization.swift */; };
+		E292B9C91B92380300D75DE2 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9C81B92380300D75DE2 /* Extensions.swift */; };
+		E292B9CB1B92384B00D75DE2 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E292B9CA1B92384B00D75DE2 /* PBXObject.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,7 +36,7 @@
 		E21D91B61B7B1A9000FD0374 /* XCProjectFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCProjectFile.swift; sourceTree = "<group>"; };
 		E292B9C41B9236B500D75DE2 /* Serialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serialization.swift; sourceTree = "<group>"; };
 		E292B9C81B92380300D75DE2 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		E292B9CA1B92384B00D75DE2 /* PBXObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; };
+		E292B9CA1B92384B00D75DE2 /* PBXObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; tabWidth = 2; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
This is so the developers contributing to this project won’t need to change their Xcode settings if they do not work with 2 space indents and tabs.
