### PR TITLE
.gitignore update to ignore *.xcscmblueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+*.xcscmblueprint
 
 # CocoaPods
 #


### PR DESCRIPTION
I believe this file used/created by Xcode 7 and up.

GitHub had added it to [their Swift .gitignore](https://github.com/github/gitignore/blob/master/Swift.gitignore).
