### PR TITLE
Make PBXFileReference return an optional full path

### DIFF
--- a/Xcode/Xcode/PBXObject.swift
+++ b/Xcode/Xcode/PBXObject.swift
@@ -130,7 +130,7 @@ public class PBXReference : PBXContainerItem {
 public class PBXFileReference : PBXReference {
 
   // convenience accessor
-  public lazy var fullPath: Path = self.allObjects.fullFilePaths[self.id]!
+  public lazy var fullPath: Path? = self.allObjects.fullFilePaths[self.id]
 }
 
 public class PBXGroup : PBXReference {


### PR DESCRIPTION
The filesystem path to a `PBXReference` may not always exist in the `fullFilePaths`
dictionary, for example when the user incorrectly edits (or merges) their Xcode project file.

I would like to catch this error in R.swift, but can't because this dictionary lookup in Xcode.swift is already a fatal error.
