### PR TITLE
add support for build settings

### DIFF
--- a/Xcode/Xcode/PBXObject.swift
+++ b/Xcode/Xcode/PBXObject.swift
@@ -118,8 +118,18 @@ public class PBXSourcesBuildPhase : PBXBuildPhase {
 public class PBXBuildStyle : PBXProjectItem {
 }
 
+public class BuildSettings {
+
+  let sdkRoot: String
+
+  init(object: [String: AnyObject]) {
+    self.sdkRoot = object["SDKROOT"] as! String
+  }
+}
+
 public class XCBuildConfiguration : PBXBuildStyle {
   public lazy var name: String = self.string("name")!
+  public lazy var buildSettings: BuildSettings = BuildSettings(object: self.dict["buildSettings"] as! [String: AnyObject])
 }
 
 public /* abstract */ class PBXTarget : PBXProjectItem {
@@ -139,6 +149,7 @@ public class PBXTargetDependency : PBXProjectItem {
 }
 
 public class XCConfigurationList : PBXProjectItem {
+  public lazy var buildConfigurations: [XCBuildConfiguration] = self.objects("buildConfigurations")
 }
 
 public class PBXReference : PBXContainerItem {

--- a/Xcode/Xcode/PBXObject.swift
+++ b/Xcode/Xcode/PBXObject.swift
@@ -120,10 +120,32 @@ public class PBXBuildStyle : PBXProjectItem {
 
 public class BuildSettings {
 
-  let sdkRoot: String
+  let ASSETCATALOG_COMPILER_APPICON_NAME: String
+  let CLANG_ANALYZER_NONNULL: Bool
+  let DEBUG_INFORMATION_FORMAT: String
+  let EMBEDDED_CONTENT_CONTAINS_SWIFT: Bool
+  let IBSC_MODULE: String
+  let INFOPLIST_FILE: String
+  let PRODUCT_BUNDLE_IDENTIFIER: String
+  let PRODUCT_NAME: String
+  let SDKROOT: String
+  let SKIP_INSTALL: Bool
+  let TARGETED_DEVICE_FAMILY: String
+  let WATCHOS_DEPLOYMENT_TARGET: String
 
   init(object: [String: AnyObject]) {
-    self.sdkRoot = object["SDKROOT"] as! String
+    self.ASSETCATALOG_COMPILER_APPICON_NAME = object["ASSETCATALOG_COMPILER_APPICON_NAME"] as! String
+    self.CLANG_ANALYZER_NONNULL = object["CLANG_ANALYZER_NONNULL"] as! String == "YES"
+    self.DEBUG_INFORMATION_FORMAT = object["DEBUG_INFORMATION_FORMAT"] as! String
+    self.EMBEDDED_CONTENT_CONTAINS_SWIFT = object["EMBEDDED_CONTENT_CONTAINS_SWIFT"] as! String == "YES"
+    self.IBSC_MODULE = object["IBSC_MODULE"] as! String
+    self.INFOPLIST_FILE = object["INFOPLIST_FILE"] as! String
+    self.PRODUCT_BUNDLE_IDENTIFIER = object["PRODUCT_BUNDLE_IDENTIFIER"] as! String
+    self.PRODUCT_NAME = object["PRODUCT_NAME"] as! String
+    self.SDKROOT = object["SDKROOT"] as! String
+    self.SKIP_INSTALL = object["SKIP_INSTALL"] as! String == "YES"
+    self.TARGETED_DEVICE_FAMILY = object["TARGETED_DEVICE_FAMILY"] as! String
+    self.WATCHOS_DEPLOYMENT_TARGET = object["WATCHOS_DEPLOYMENT_TARGET"] as! String
   }
 }
 

--- a/Xcode/Xcode/PBXObject.swift
+++ b/Xcode/Xcode/PBXObject.swift
@@ -120,32 +120,34 @@ public class PBXBuildStyle : PBXProjectItem {
 
 public class BuildSettings {
 
-  let ASSETCATALOG_COMPILER_APPICON_NAME: String
-  let CLANG_ANALYZER_NONNULL: Bool
-  let DEBUG_INFORMATION_FORMAT: String
-  let EMBEDDED_CONTENT_CONTAINS_SWIFT: Bool
-  let IBSC_MODULE: String
-  let INFOPLIST_FILE: String
-  let PRODUCT_BUNDLE_IDENTIFIER: String
-  let PRODUCT_NAME: String
-  let SDKROOT: String
-  let SKIP_INSTALL: Bool
-  let TARGETED_DEVICE_FAMILY: String
-  let WATCHOS_DEPLOYMENT_TARGET: String
+  let ASSETCATALOG_COMPILER_APPICON_NAME: String?
+  let CLANG_ANALYZER_NONNULL: Bool?
+  let DEBUG_INFORMATION_FORMAT: String?
+  let EMBEDDED_CONTENT_CONTAINS_SWIFT: Bool?
+  let IBSC_MODULE: String?
+  let INFOPLIST_FILE: String?
+  let PRODUCT_BUNDLE_IDENTIFIER: String?
+  let PRODUCT_NAME: String?
+  let SDKROOT: String?
+  let SKIP_INSTALL: Bool?
+  let TARGETED_DEVICE_FAMILY: String?
+  let WATCHOS_DEPLOYMENT_TARGET: String?
+  let IPHONEOS_DEPLOYMENT_TARGET: String?
 
   init(object: [String: AnyObject]) {
-    self.ASSETCATALOG_COMPILER_APPICON_NAME = object["ASSETCATALOG_COMPILER_APPICON_NAME"] as! String
-    self.CLANG_ANALYZER_NONNULL = object["CLANG_ANALYZER_NONNULL"] as! String == "YES"
-    self.DEBUG_INFORMATION_FORMAT = object["DEBUG_INFORMATION_FORMAT"] as! String
-    self.EMBEDDED_CONTENT_CONTAINS_SWIFT = object["EMBEDDED_CONTENT_CONTAINS_SWIFT"] as! String == "YES"
-    self.IBSC_MODULE = object["IBSC_MODULE"] as! String
-    self.INFOPLIST_FILE = object["INFOPLIST_FILE"] as! String
-    self.PRODUCT_BUNDLE_IDENTIFIER = object["PRODUCT_BUNDLE_IDENTIFIER"] as! String
-    self.PRODUCT_NAME = object["PRODUCT_NAME"] as! String
-    self.SDKROOT = object["SDKROOT"] as! String
-    self.SKIP_INSTALL = object["SKIP_INSTALL"] as! String == "YES"
-    self.TARGETED_DEVICE_FAMILY = object["TARGETED_DEVICE_FAMILY"] as! String
-    self.WATCHOS_DEPLOYMENT_TARGET = object["WATCHOS_DEPLOYMENT_TARGET"] as! String
+    self.ASSETCATALOG_COMPILER_APPICON_NAME = object["ASSETCATALOG_COMPILER_APPICON_NAME"] as? String
+    self.CLANG_ANALYZER_NONNULL = (object["CLANG_ANALYZER_NONNULL"] as? String).map { $0 == "YES" }
+    self.DEBUG_INFORMATION_FORMAT = object["DEBUG_INFORMATION_FORMAT"] as? String
+    self.EMBEDDED_CONTENT_CONTAINS_SWIFT = (object["EMBEDDED_CONTENT_CONTAINS_SWIFT"] as? String).map { $0 == "YES" }
+    self.IBSC_MODULE = object["IBSC_MODULE"] as? String
+    self.INFOPLIST_FILE = object["INFOPLIST_FILE"] as? String
+    self.PRODUCT_BUNDLE_IDENTIFIER = object["PRODUCT_BUNDLE_IDENTIFIER"] as? String
+    self.PRODUCT_NAME = object["PRODUCT_NAME"] as? String
+    self.SDKROOT = object["SDKROOT"] as? String
+    self.SKIP_INSTALL = (object["SKIP_INSTALL"] as? String).map { $0 == "YES" }
+    self.TARGETED_DEVICE_FAMILY = object["TARGETED_DEVICE_FAMILY"] as? String
+    self.WATCHOS_DEPLOYMENT_TARGET = object["WATCHOS_DEPLOYMENT_TARGET"] as? String
+    self.IPHONEOS_DEPLOYMENT_TARGET = object["IPHONEOS_DEPLOYMENT_TARGET"] as? String
   }
 }
 


### PR DESCRIPTION
I started working on WatchOS support for R.swift, and I need to have the `SDKROOT` in order to know which target is being build and act accordingly.

https://github.com/mac-cain13/R.swift/pull/213

Used format in pbxproj:

```
/* Begin XCBuildConfiguration section */
        C30E261F1CE74DBA009C38E5 /* Debug */ = {
            isa = XCBuildConfiguration;
            buildSettings = {
                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
                CLANG_ANALYZER_NONNULL = YES;
                DEBUG_INFORMATION_FORMAT = dwarf;
                EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
                IBSC_MODULE = ResourceAppWatchApp_Extension;
                INFOPLIST_FILE = ResourceAppWatchApp/Info.plist;
                PRODUCT_BUNDLE_IDENTIFIER = nl.mathijskadijk.ResourceApp.watchkitapp;
                PRODUCT_NAME = "$(TARGET_NAME)";
                SDKROOT = watchos;
                SKIP_INSTALL = YES;
                TARGETED_DEVICE_FAMILY = 4;
                WATCHOS_DEPLOYMENT_TARGET = 2.2;
            };
            name = Debug;
        };
```
