### PR TITLE
Upgrade to Swift 2.3

### DIFF
--- a/Xcode/Xcode/Serialization.swift
+++ b/Xcode/Xcode/Serialization.swift
@@ -15,7 +15,9 @@ extension XCProjectFile {
     try NSFileManager.defaultManager().createDirectoryAtURL(url, withIntermediateDirectories: true, attributes: nil)
 
     let name = try XCProjectFile.projectName(url)
-    let path = url.URLByAppendingPathComponent("project.pbxproj")
+    guard let path = url.URLByAppendingPathComponent("project.pbxproj", isDirectory: false) else {
+      throw ProjectFileError.MissingPbxproj
+    }
 
     let serializer = Serializer(projectName: name, projectFile: self)
     let plformat = format ?? self.format

--- a/Xcode/Xcode/XCProjectFile.swift
+++ b/Xcode/Xcode/XCProjectFile.swift
@@ -47,8 +47,9 @@ public class XCProjectFile {
 
   public convenience init(xcodeprojURL: NSURL) throws {
 
-    let pbxprojURL = xcodeprojURL.URLByAppendingPathComponent("project.pbxproj")
-    guard let data = NSData(contentsOfURL: pbxprojURL) else {
+
+    guard let pbxprojURL = xcodeprojURL.URLByAppendingPathComponent("project.pbxproj", isDirectory: false),
+              data = NSData(contentsOfURL: pbxprojURL) else {
       throw ProjectFileError.MissingPbxproj
     }
 


### PR DESCRIPTION
Think it would be nice to have a version that is compatible with Swift 2.3. After this version we can continue to upgrade to Swift 3.
