### PR TITLE
Add PLATFORM_DIR support

### DIFF
--- a/Sources/PBXObject.swift
+++ b/Sources/PBXObject.swift
@@ -366,6 +366,7 @@ public enum SourceTreeFolder: String, Equatable {
   case buildProductsDir = "BUILT_PRODUCTS_DIR"
   case developerDir = "DEVELOPER_DIR"
   case sdkRoot = "SDKROOT"
+  case platformDir = "PLATFORM_DIR"
 
   public static func ==(lhs: SourceTreeFolder, rhs: SourceTreeFolder) -> Bool {
     return lhs.rawValue == rhs.rawValue

--- a/Sources/XCProjectFile.swift
+++ b/Sources/XCProjectFile.swift
@@ -167,6 +167,9 @@ public class XCProjectFile {
 
         case .relativeTo(.sdkRoot):
           str = path
+
+        case .relativeTo(.platformDir):
+          str = path
         }
 
         ps += paths(group, prefix: str)


### PR DESCRIPTION
We have a few Xcode project files with the value of `PLATFORM_DIR` where most projects have set `SOURCE_ROOT`. 

This most often occurs in something like this: 
```
1DD70E00000 /* XCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = XCTest.framework; path = Developer/Library/Frameworks/XCTest.framework; sourceTree = PLATFORM_DIR; };
```