### PR TITLE
fix: url(with:) only available in iOS 9

### DIFF
--- a/Sources/XcodeEdit/PBXObject.swift
+++ b/Sources/XcodeEdit/PBXObject.swift
@@ -403,6 +403,7 @@ public enum Path: Equatable {
   case absolute(String)
   case relativeTo(SourceTreeFolder, String)
 
+  @available(iOS 9.0, *)
   @available(OSX 10.11, *)
   public func url(with urlForSourceTreeFolder: (SourceTreeFolder) -> URL) -> URL {
     switch self {


### PR DESCRIPTION
Used RSwift with SwiftUI, had to do this to make the preview works. Although I'm not sure this is the proper way of addressing the problem. (Did same PR also on RSwift, see https://github.com/mac-cain13/R.swift/pull/599)