### PR TITLE
Add fullPath to PBXFileSystemSynchronizedRootGroup

### DIFF
--- a/Sources/XcodeEdit/PBXObject.swift
+++ b/Sources/XcodeEdit/PBXObject.swift
@@ -382,6 +382,13 @@ public class PBXGroup : PBXReference {
     }
   }
 
+  public var syncRoots: [Reference<PBXFileSystemSynchronizedRootGroup>] {
+    return _children.compactMap { childRef in
+      guard let _ = childRef.value as? PBXFileSystemSynchronizedRootGroup else { return nil }
+      return Reference(allObjects: childRef.allObjects, id: childRef.id)
+    }
+  }
+
   // Custom function for R.swift
   public func insertFileReference(_ fileReference: Reference<PBXFileReference>, at index: Int) {
     if fileRefs.contains(fileReference) { return }
@@ -402,6 +409,11 @@ public class PBXFileSystemSynchronizedRootGroup : PBXReference {
     self.exceptions = allObjects.createOptionalReferences(ids: try fields.optionalIds("exceptions"))
 
     try super.init(id: id, fields: fields, allObjects: allObjects)
+  }
+
+  // convenience accessor
+  public var fullPath: Path? {
+    return self.allObjects.fullFilePaths[self.id]
   }
 }
 

--- a/Sources/XcodeEdit/XCProjectFile.swift
+++ b/Sources/XcodeEdit/XCProjectFile.swift
@@ -156,6 +156,31 @@ public class XCProjectFile {
       }
     }
 
+    let syncRoots = current.syncRoots.compactMap { $0.value }
+    for sync in syncRoots {
+      guard let path = sync.path else { continue }
+
+      switch sync.sourceTree {
+      case .group:
+        switch current.sourceTree {
+        case .absolute:
+          ps[sync.id] = .absolute(prefix + path)
+
+        case .group:
+          ps[sync.id] = .relativeTo(.sourceRoot, prefix + path)
+
+        case .relativeTo(let sourceTreeFolder):
+          ps[sync.id] = .relativeTo(sourceTreeFolder, prefix + path)
+        }
+
+      case .absolute:
+        ps[sync.id] = .absolute(path)
+
+      case let .relativeTo(sourceTreeFolder):
+        ps[sync.id] = .relativeTo(sourceTreeFolder, path)
+      }
+    }
+
     let subGroups = current.subGroups.compactMap { $0.value }
     for group in subGroups {
       if let path = group.path {


### PR DESCRIPTION
 R.swift needs fullPath property on PBXFileSystemSynchronizedRootGroup to access contents of Xcode 16 folders.